### PR TITLE
Remove .html requirement from URL matcher.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     },
     "content_scripts": [
         {
-            "matches": ["*://*/*/SpecRunner.html*"],
+            "matches": ["*://*/*/SpecRunner*"],
             "css": [
                 "css/codemirror.css",
                 "css/mergely.css",


### PR DESCRIPTION
This way the scripts will run on URLs like `http://example.com/Specs/SpecRunner` if you have Apache set up to load that correctly.
